### PR TITLE
Fix D3D12 pixel history MRT shader out results.

### DIFF
--- a/renderdoc/data/hlsl/d3d12_pixelhistory.hlsl
+++ b/renderdoc/data/hlsl/d3d12_pixelhistory.hlsl
@@ -150,14 +150,25 @@ float4 RENDERDOC_PrimitiveIDPS(uint prim : SV_PrimitiveID) : SV_Target0
 
 struct MultipleOutput
 {
-  float4 col0 : SV_Target0;
-  float4 col1 : SV_Target1;
-  float4 col2 : SV_Target2;
-  float4 col3 : SV_Target3;
-  float4 col4 : SV_Target4;
-  float4 col5 : SV_Target5;
-  float4 col6 : SV_Target6;
-  float4 col7 : SV_Target7;
+#if RT == 0
+  float4 col : SV_Target0;
+#elif RT == 1
+  float4 col : SV_Target1;
+#elif RT == 2
+  float4 col : SV_Target2;
+#elif RT == 3
+  float4 col : SV_Target3;
+#elif RT == 4
+  float4 col : SV_Target4;
+#elif RT == 5
+  float4 col : SV_Target5;
+#elif RT == 6
+  float4 col : SV_Target6;
+#elif RT == 7
+  float4 col : SV_Target7;
+#else
+  float4 col;
+#endif
 };
 
 MultipleOutput RENDERDOC_PixelHistoryFixedColPS()
@@ -165,7 +176,7 @@ MultipleOutput RENDERDOC_PixelHistoryFixedColPS()
   MultipleOutput OUT = (MultipleOutput)0;
 
   float4 color = float4(0.1f, 0.2f, 0.3f, 0.4f);
-  OUT.col0 = OUT.col1 = OUT.col2 = OUT.col3 = OUT.col4 = OUT.col5 = OUT.col6 = OUT.col7 = color;
+  OUT.col = color;
 
   return OUT;
 }

--- a/renderdoc/data/hlsl/d3d12_pixelhistory.hlsl
+++ b/renderdoc/data/hlsl/d3d12_pixelhistory.hlsl
@@ -148,7 +148,7 @@ float4 RENDERDOC_PrimitiveIDPS(uint prim : SV_PrimitiveID) : SV_Target0
   return asfloat(prim).xxxx;
 }
 
-struct MultipleOutput
+struct SelectedOutput
 {
 #if RT == 0
   float4 col : SV_Target0;
@@ -171,9 +171,9 @@ struct MultipleOutput
 #endif
 };
 
-MultipleOutput RENDERDOC_PixelHistoryFixedColPS()
+SelectedOutput RENDERDOC_PixelHistoryFixedColPS()
 {
-  MultipleOutput OUT = (MultipleOutput)0;
+  SelectedOutput OUT = (SelectedOutput)0;
 
   float4 color = float4(0.1f, 0.2f, 0.3f, 0.4f);
   OUT.col = color;

--- a/renderdoc/driver/d3d12/d3d12_debug.cpp
+++ b/renderdoc/driver/d3d12/d3d12_debug.cpp
@@ -2916,7 +2916,7 @@ void D3D12Replay::PixelHistory::Init(WrappedID3D12Device *device, D3D12DebugMana
   shaderCache->GetShaderBlob(hlsl.c_str(), "RENDERDOC_PrimitiveIDPS",
                              D3DCOMPILE_WARNINGS_ARE_ERRORS, {}, "ps_6_0", &PrimitiveIDPSDxil);
 
-  for(int i = 0; i < 8; ++i)
+  for(int i = 0; i < D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT; ++i)
   {
     rdcstr hlsl_variant = "#define RT " + ToStr(i) + "\n" + hlsl;
     shaderCache->GetShaderBlob(hlsl_variant.c_str(), "RENDERDOC_PixelHistoryFixedColPS",
@@ -2932,11 +2932,10 @@ void D3D12Replay::PixelHistory::Release()
 {
   SAFE_RELEASE(PrimitiveIDPS);
   SAFE_RELEASE(PrimitiveIDPSDxil);
-  for(int i = 0; i < 8; ++i)
-  {
+  for(int i = 0; i < ARRAY_COUNT(FixedColorPS); ++i)
     SAFE_RELEASE(FixedColorPS[i]);
+  for(int i = 0; i < ARRAY_COUNT(FixedColorPSDxil); ++i)
     SAFE_RELEASE(FixedColorPSDxil[i]);
-  }
 }
 
 void D3D12Replay::HistogramMinMax::Init(WrappedID3D12Device *device, D3D12DebugManager *debug)

--- a/renderdoc/driver/d3d12/d3d12_debug.cpp
+++ b/renderdoc/driver/d3d12/d3d12_debug.cpp
@@ -2916,10 +2916,14 @@ void D3D12Replay::PixelHistory::Init(WrappedID3D12Device *device, D3D12DebugMana
   shaderCache->GetShaderBlob(hlsl.c_str(), "RENDERDOC_PrimitiveIDPS",
                              D3DCOMPILE_WARNINGS_ARE_ERRORS, {}, "ps_6_0", &PrimitiveIDPSDxil);
 
-  shaderCache->GetShaderBlob(hlsl.c_str(), "RENDERDOC_PixelHistoryFixedColPS",
-                             D3DCOMPILE_WARNINGS_ARE_ERRORS, {}, "ps_5_0", &FixedColorPS);
-  shaderCache->GetShaderBlob(hlsl.c_str(), "RENDERDOC_PixelHistoryFixedColPS",
-                             D3DCOMPILE_WARNINGS_ARE_ERRORS, {}, "ps_6_0", &FixedColorPSDxil);
+  for(int i = 0; i < 8; ++i)
+  {
+    rdcstr hlsl_variant = "#define RT " + ToStr(i) + "\n" + hlsl;
+    shaderCache->GetShaderBlob(hlsl_variant.c_str(), "RENDERDOC_PixelHistoryFixedColPS",
+                               D3DCOMPILE_WARNINGS_ARE_ERRORS, {}, "ps_5_0", &FixedColorPS[i]);
+    shaderCache->GetShaderBlob(hlsl_variant.c_str(), "RENDERDOC_PixelHistoryFixedColPS",
+                               D3DCOMPILE_WARNINGS_ARE_ERRORS, {}, "ps_6_0", &FixedColorPSDxil[i]);
+  }
 
   shaderCache->SetCaching(false);
 }
@@ -2928,8 +2932,11 @@ void D3D12Replay::PixelHistory::Release()
 {
   SAFE_RELEASE(PrimitiveIDPS);
   SAFE_RELEASE(PrimitiveIDPSDxil);
-  SAFE_RELEASE(FixedColorPS);
-  SAFE_RELEASE(FixedColorPSDxil);
+  for(int i = 0; i < 8; ++i)
+  {
+    SAFE_RELEASE(FixedColorPS[i]);
+    SAFE_RELEASE(FixedColorPSDxil[i]);
+  }
 }
 
 void D3D12Replay::HistogramMinMax::Init(WrappedID3D12Device *device, D3D12DebugManager *debug)

--- a/renderdoc/driver/d3d12/d3d12_pixelhistory.cpp
+++ b/renderdoc/driver/d3d12/d3d12_pixelhistory.cpp
@@ -426,11 +426,12 @@ void D3D12DebugManager::PixelHistoryCopyPixel(ID3D12GraphicsCommandListX *cmd,
 struct D3D12PixelHistoryShaderCache
 {
   D3D12PixelHistoryShaderCache(WrappedID3D12Device *device, ID3DBlob *PersistentPrimIDPS,
-                               ID3DBlob *PersistentPrimIDPSDxil, ID3DBlob *FixedColorPS[8],
-                               ID3DBlob *FixedColorPSDxil[8])
+                               ID3DBlob *PersistentPrimIDPSDxil,
+                               ID3DBlob *FixedColorPS[D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT],
+                               ID3DBlob *FixedColorPSDxil[D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT])
       : m_pDevice(device), m_PrimIDPS(PersistentPrimIDPS), m_PrimIDPSDxil(PersistentPrimIDPSDxil)
   {
-    for(int i = 0; i < 8; ++i)
+    for(int i = 0; i < D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT; ++i)
     {
       m_FixedColorPS[i] = FixedColorPS[i];
       m_FixedColorPSDxil[i] = FixedColorPSDxil[i];
@@ -455,8 +456,8 @@ private:
 
   ID3DBlob *m_PrimIDPS;
   ID3DBlob *m_PrimIDPSDxil;
-  ID3DBlob *m_FixedColorPS[8];
-  ID3DBlob *m_FixedColorPSDxil[8];
+  ID3DBlob *m_FixedColorPS[D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT];
+  ID3DBlob *m_FixedColorPSDxil[D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT];
 };
 
 // D3D12PixelHistoryCallback is a generic D3D12ActionCallback that can be used

--- a/renderdoc/driver/d3d12/d3d12_pixelhistory.cpp
+++ b/renderdoc/driver/d3d12/d3d12_pixelhistory.cpp
@@ -728,8 +728,7 @@ struct D3D12OcclusionCallback : public D3D12PixelHistoryCallback
 
     pipeState.rts.clear();
     pipeState.dsv = *m_CallbackInfo.dsDescriptor;
-    ID3D12PipelineState *pso =
-        GetPixelOcclusionPipeline(eid, pipeState);
+    ID3D12PipelineState *pso = GetPixelOcclusionPipeline(eid, pipeState);
 
     pipeState.pipe = GetResID(pso);
     // set the scissor

--- a/renderdoc/driver/d3d12/d3d12_pixelhistory.cpp
+++ b/renderdoc/driver/d3d12/d3d12_pixelhistory.cpp
@@ -729,7 +729,7 @@ struct D3D12OcclusionCallback : public D3D12PixelHistoryCallback
     pipeState.rts.clear();
     pipeState.dsv = *m_CallbackInfo.dsDescriptor;
     ID3D12PipelineState *pso =
-        GetPixelOcclusionPipeline(eid, pipeState, GetPixelHistoryRenderTargetIndex(pipeState));
+        GetPixelOcclusionPipeline(eid, pipeState);
 
     pipeState.pipe = GetResID(pso);
     // set the scissor
@@ -847,11 +847,8 @@ struct D3D12OcclusionCallback : public D3D12PixelHistoryCallback
   }
 
 private:
-  ID3D12PipelineState *GetPixelOcclusionPipeline(uint32_t eid, D3D12RenderState &state,
-                                                 uint32_t outputIndex)
+  ID3D12PipelineState *GetPixelOcclusionPipeline(uint32_t eid, D3D12RenderState &state)
   {
-    // TODO: outputIndex is unused. Either we need to select a fixed color shader that writes to the
-    // preferred RT, or use RenderTargetWriteMask in the blend desc to mask out unrelated RTs
     auto it = m_PipeCache.find(state.pipe);
     if(it != m_PipeCache.end())
       return it->second;

--- a/renderdoc/driver/d3d12/d3d12_replay.h
+++ b/renderdoc/driver/d3d12/d3d12_replay.h
@@ -503,8 +503,8 @@ private:
     ID3DBlob *PrimitiveIDPS = NULL;
     ID3DBlob *PrimitiveIDPSDxil = NULL;
 
-    ID3DBlob *FixedColorPS[8] = {NULL};
-    ID3DBlob *FixedColorPSDxil[8] = {NULL};
+    ID3DBlob *FixedColorPS[D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT] = {NULL};
+    ID3DBlob *FixedColorPSDxil[D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT] = {NULL};
   } m_PixelHistory;
 
   struct HistogramMinMax

--- a/renderdoc/driver/d3d12/d3d12_replay.h
+++ b/renderdoc/driver/d3d12/d3d12_replay.h
@@ -503,8 +503,8 @@ private:
     ID3DBlob *PrimitiveIDPS = NULL;
     ID3DBlob *PrimitiveIDPSDxil = NULL;
 
-    ID3DBlob *FixedColorPS = NULL;
-    ID3DBlob *FixedColorPSDxil = NULL;
+    ID3DBlob *FixedColorPS[8] = {NULL};
+    ID3DBlob *FixedColorPSDxil[8] = {NULL};
   } m_PixelHistory;
 
   struct HistogramMinMax


### PR DESCRIPTION
* Previously the color target was always bound as RT0 regardless of which RT we wanted history for, meaning shader out and post mod results were showing as the values written to RT0.
* The color target is now bound to the slot of the target of history for both shader out and post mod paths, but remains bound to RT0 for the primitive ID path as that shader always writes to RT0.

<!--
Before submitting a pull request you are strongly recommended to read the
docs/CONTRIBUTING.md file which gives some information on how to prepare a
change:

https://github.com/baldurk/renderdoc/blob/v1.x/docs/CONTRIBUTING.md

For small changes you don't have to read the document end to end, but should at
least look at the sections on how to ensure your code and commits are formatted
according to the style requirements.
-->

## Description

<!--
Describe here what your pull request changes and why it should happen. For small
changes which are obvious this can just be a line or two - even the commit
message is sometimes enough.
-->
Figured I'd try out the suggestion to perform intermediate reviews in my fork, @Zorro666. This is the same as the previous change you looked at but with a minor fix to the pipeline's depth format being inside a branch it shouldn't have been in. And also clang-format having been applied. 
I believe however that now that multiple rendertargets are bound to the shader-out and post-mod passes, this introduces a potential error due to the side effects by passes being written to the capture sources. I think this can be fixed by adjusting the RenderTargetWriteMask on these two passes. 